### PR TITLE
Fix Reasoning Prompt When Using Chat Templates

### DIFF
--- a/recipes/accelerate_configs/fsdp.yaml
+++ b/recipes/accelerate_configs/fsdp.yaml
@@ -1,0 +1,61 @@
+# options that can be used with accelerate config are neatly documented here - 
+# https://github.com/huggingface/accelerate/blob/ee163b66fb7848892519e804688cb4ae981aacbe/docs/source/package_reference/cli.md
+
+# type of compute environment, no need to change
+compute_environment: LOCAL_MACHINE # AMAZON_SAGEMAKER
+
+# use FSDP distributed compute
+distributed_type: FSDP
+
+# FSDP specific configurations
+fsdp_config:
+  
+  # use this for training transformers
+  fsdp_auto_wrap_policy: TRANSFORMER_BASED_WRAP
+
+  # this controls the FSDP pipelining
+  fsdp_backward_prefetch: BACKWARD_PRE # set to BACKWARD_PRE for the most time-efficient pipeline
+                                              # but requires the most memory. BACKWARD_POST is the less
+                                              # memory intensive option
+  fsdp_backward_prefetch_policy: BACKWARD_PRE # for backward compatibility accelerate<1.0
+
+  # setting this to true will increase forward memory by prefetching the next FSDP all-gather, while performing
+  # the current forward pass. 
+  fsdp_forward_prefetch: false
+
+  # setting this will offload model and optimizer parameters to the CPU, to save GPU memory at a significant
+  # increase of CPU time.
+  fsdp_offload_params: false
+  
+  fsdp_sharding_strategy: 1 # set to FULL_SHARD (1), SHARD_GRAD_OP (2), 
+                            # 3 is NO_SHARD, effectively disabling FSDP
+                            # 4, 5 are HYBRID_ modes for multi-node training only.
+
+  fsdp_state_dict_type: FULL_STATE_DICT # set to FULL_STATE_DICT (1), SHARDED_STATE_DICT (3)
+                                        # 2 is LOCAL_STATE_DICT where parameters are still flattened
+                                        # 3 is efficient, but requires know-how to use the shared checkpoint.
+ 
+  fsdp_cpu_ram_efficient_loading: true # for large models set to true, model loaded on single process
+  fsdp_sync_module_states: true # for large models set to true, model loaded on single process
+
+  # not needed for HF models that have . _no_split_modules
+  # the example below is for GPTBigCode
+  # fsdp_transformer_layer_cls_to_wrap: "GPTBigCodeBlock” 
+
+# for "autocast" mixed precision training, where the weights of the model are kept at higher precision, but the 
+# learning products (e.g., gradients, model parameters) are kept at a lower precision. Default is 'no'. Other options
+# would be fp16, bf16, etc.
+mixed_precision: 'no'
+
+machine_rank: 0 # rank of the machine where accelerate is launched
+num_machines: 1
+num_processes: 1  # default, override with --num_processes
+
+# the rendezvous method to use in distributed training. Other option is c10d
+rdzv_backend: static
+same_network: true
+
+# below arguments are required when training in multi-node setup
+# for multi-gpu single node, the below values default to
+# main_process_ip: 127.0.0.1 # override with --main_process_ip
+# main_process_port: 29500 # override with --main_process_port

--- a/recipes/accelerate_configs/fsdp.yaml
+++ b/recipes/accelerate_configs/fsdp.yaml
@@ -31,12 +31,15 @@ fsdp_config:
                             # 3 is NO_SHARD, effectively disabling FSDP
                             # 4, 5 are HYBRID_ modes for multi-node training only.
 
-  fsdp_state_dict_type: FULL_STATE_DICT # set to FULL_STATE_DICT (1), SHARDED_STATE_DICT (3)
+  fsdp_state_dict_type: SHARDED_STATE_DICT # set to FULL_STATE_DICT (1), SHARDED_STATE_DICT (3)
                                         # 2 is LOCAL_STATE_DICT where parameters are still flattened
                                         # 3 is efficient, but requires know-how to use the shared checkpoint.
  
   fsdp_cpu_ram_efficient_loading: true # for large models set to true, model loaded on single process
   fsdp_sync_module_states: true # for large models set to true, model loaded on single process
+
+  fsdp_activation_checkpointing: true # better to use the FSDP version
+  fsdp_use_orig_params: false # accelerate seems to set this to True by default now
 
   # not needed for HF models that have . _no_split_modules
   # the example below is for GPTBigCode

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -97,6 +97,13 @@ class GRPOScriptArguments(ScriptArguments):
         metadata={"help": "Maximum (negative) penalty for for repetition penalty reward"},
     )
 
+    user_content_field: str = field(
+        default="problem",
+        metadata={"help": "example field for extracting user content"},
+    )
+
+
+
 
 SYSTEM_PROMPT = (
     "A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant "
@@ -172,7 +179,7 @@ def main(script_args, training_args, model_args):
         return {
             "prompt": [
                 {"role": "system", "content": SYSTEM_PROMPT},
-                {"role": "user", "content": example["problem"]},
+                {"role": "user", "content": example[script_args.user_content_field]},
             ],
         }
 
@@ -180,19 +187,6 @@ def main(script_args, training_args, model_args):
     for split in dataset:
         if "messages" in dataset[split].column_names:
             dataset[split] = dataset[split].remove_columns("messages")
-
-    logger.info("*** Initializing model kwargs ***")
-    torch_dtype = (
-        model_args.torch_dtype if model_args.torch_dtype in ["auto", None] else getattr(torch, model_args.torch_dtype)
-    )
-    model_kwargs = dict(
-        revision=model_args.model_revision,
-        trust_remote_code=model_args.trust_remote_code,
-        attn_implementation=model_args.attn_implementation,
-        torch_dtype=torch_dtype,
-        use_cache=False if training_args.gradient_checkpointing else True,
-    )
-    training_args.model_init_kwargs = model_kwargs
 
     #############################
     # Initialize the GRPO trainer

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -108,8 +108,8 @@ class GRPOScriptArguments(ScriptArguments):
 SYSTEM_PROMPT = (
     "A conversation between User and Assistant. The user asks a question, and the Assistant solves it. The assistant "
     "first thinks about the reasoning process in the mind and then provides the user with the answer. The reasoning "
-    "process and answer are enclosed within <think> </think> and <answer> </answer> tags, respectively, i.e., "
-    "<think> reasoning process here </think><answer> answer here </answer>"
+    "process is enclosed within <think> </think> and the answer is given in the \\boxed environment, respectively, i.e., "
+    "<think> reasoning process here </think> \\boxed{answer here}."
 )
 
 
@@ -187,6 +187,17 @@ def main(script_args, training_args, model_args):
     for split in dataset:
         if "messages" in dataset[split].column_names:
             dataset[split] = dataset[split].remove_columns("messages")
+
+    #############################
+    # Update the tokenizer 
+    #############################
+    processing_class = AutoTokenizer.from_pretrained(
+        model_args.model_name_or_path, padding_side="left",
+        trust_remote_code=training_args.model_init_kwargs
+.get("trust_remote_code", False)
+    )
+    # add this to better prompt the think 
+    processing_class.chat_template = processing_class.chat_template + 'Let me solve this step by step.\n<think>'
 
     #############################
     # Initialize the GRPO trainer

--- a/src/open_r1/grpo.py
+++ b/src/open_r1/grpo.py
@@ -21,7 +21,7 @@ import datasets
 import torch
 import transformers
 from datasets import load_dataset
-from transformers import set_seed
+from transformers import set_seed, AutoTokenizer
 from transformers.trainer_utils import get_last_checkpoint
 
 from open_r1.configs import GRPOConfig
@@ -208,6 +208,7 @@ def main(script_args, training_args, model_args):
         args=training_args,
         train_dataset=dataset[script_args.dataset_train_split],
         eval_dataset=dataset[script_args.dataset_test_split] if training_args.eval_strategy != "no" else None,
+        processing_class=processing_class,
         peft_config=get_peft_config(model_args),
         callbacks=get_callbacks(training_args, model_args),
     )

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -29,7 +29,7 @@ def accuracy_reward(completions, solution, **kwargs):
                             malformed_operators=False,
                             basic_latex=True,
                             equations=True,
-                            boxed="all",
+                            boxed="last",
                             units=True,
                         ),
                         # Ensures that boxed is tried first
@@ -52,7 +52,7 @@ def accuracy_reward(completions, solution, **kwargs):
 
 def format_reward(completions, **kwargs):
     """Reward function that checks if the completion has a specific format."""
-    pattern = r"^<think>.*?</think>\s*<answer>.*?</answer>$"
+    pattern = r"^.*?</think>.*\\boxed{.*}.?$"
     completion_contents = [completion[0]["content"] for completion in completions]
     matches = [re.match(pattern, content, re.DOTALL | re.MULTILINE) for content in completion_contents]
     return [1.0 if match else 0.0 for match in matches]
@@ -114,7 +114,7 @@ def len_reward(completions: list[Dict[str, str]], solutions: list[str], **kwargs
                         malformed_operators=False,
                         basic_latex=True,
                         equations=True,
-                        boxed=True,
+                        boxed="last",
                         units=True,
                     ),
                     boxed_match_priority=0,
@@ -191,7 +191,7 @@ def get_cosine_scaled_reward(
                             malformed_operators=False,
                             basic_latex=True,
                             equations=True,
-                            boxed=True,
+                            boxed="last",
                             units=True,
                         ),
                         boxed_match_priority=0,

--- a/src/open_r1/rewards.py
+++ b/src/open_r1/rewards.py
@@ -206,7 +206,9 @@ def get_cosine_scaled_reward(
 
             # Apply cosine scaling based on length
             progress = gen_len / max_len
-            cosine = math.cos(progress * math.pi)
+            # cosine = math.cos(progress * math.pi)
+            # NOTE: change to sin but dont bother renaming function
+            sine = math.sin(min(progress, 1) * math.pi / 2)
 
             if is_correct:
                 min_value = min_value_correct
@@ -216,7 +218,7 @@ def get_cosine_scaled_reward(
                 min_value = max_value_wrong
                 max_value = min_value_wrong
 
-            reward = min_value + 0.5 * (max_value - min_value) * (1.0 + cosine)
+            reward = min_value + (max_value - min_value) * sine
             rewards.append(float(reward))
 
         return rewards


### PR DESCRIPTION
This PR primarily fixes issues with how chat templates are being used for GRPO tuning. 
- The key issue is that `use_generation_prompt=True` in TRL when calling [apply_chat_template in grpo_trainer.py](https://github.com/fabianlim/trl/blob/1f344c9377d87cd348d92b78f27afea8e66563d7/trl/trainer/grpo_trainer.py#L388). However the generation prompt of a model does not necessarily contain the system prompt `'Let me solve this step by step.\n<think>'`. Hence we configure the `processing_class` and setup the `chat_template` appropriately, and pass to the GRPO trainer.
- There is an inconsistency with the math pruning logic. We set `boxed` in the `LatexExtractionConfig`, which gives high priority to a response wrapping the final answer in `\boxed{}`. However, in the previous system prompt we ask the model to give the answer in `<answer> <\answer>` instead. We make it consistent here by updating the system prompt to the `boxed` format.
- We also update the `format_reward` to search for the `\boxed` pattern appropriately.